### PR TITLE
Added docker subnet to firewall whitelist

### DIFF
--- a/openvpn.sh
+++ b/openvpn.sh
@@ -40,6 +40,7 @@ firewall() {
     iptables -A OUTPUT -o lo -j ACCEPT
     iptables -A OUTPUT -o tap0 -j ACCEPT
     iptables -A OUTPUT -o tun0 -j ACCEPT
+    iptables -A OUTPUT -d 172.17.0.0/16 -j ACCEPT
     iptables -A OUTPUT -p udp -m udp --dport 53 -j ACCEPT
     iptables -A OUTPUT -p tcp -m owner --gid-owner vpn -j ACCEPT
     iptables -A OUTPUT -p udp -m owner --gid-owner vpn -j ACCEPT


### PR DESCRIPTION
Enable this container to connect to other containers on the docker subnet.

I have been using this because some of the services I'm running services that are connecting out over the VPN, also need to connect to other docker containers for things like database/dns.