### PR TITLE
vpn.crt not always required, waiting two minutes unnecessary

### DIFF
--- a/openvpn.sh
+++ b/openvpn.sh
@@ -170,7 +170,6 @@ elif ps -ef | egrep -v 'grep|openvpn.sh' | grep -q openvpn; then
     echo "Service already running, please restart container to apply changes"
 else
     [[ -e /vpn/vpn.conf ]] || { echo "ERROR: VPN not configured!"; sleep 120; }
-    [[ -e /vpn/vpn-ca.crt ]] || { echo "ERROR: VPN cert missing!"; sleep 120; }
     [[ -x /sbin/resolvconf ]] || { cat >/sbin/resolvconf <<-EOF
 		#!/usr/bin/env bash
 		conf=/etc/resolv.conf

--- a/openvpn.sh
+++ b/openvpn.sh
@@ -169,7 +169,7 @@ elif [[ $# -ge 1 ]]; then
 elif ps -ef | egrep -v 'grep|openvpn.sh' | grep -q openvpn; then
     echo "Service already running, please restart container to apply changes"
 else
-    [[ -e /vpn/vpn.conf ]] || { echo "ERROR: VPN not configured!"; sleep 120; }
+    [[ -e /vpn/vpn.conf ]] || { echo "ERROR: VPN not configured!"; exit 1; }
     [[ -x /sbin/resolvconf ]] || { cat >/sbin/resolvconf <<-EOF
 		#!/usr/bin/env bash
 		conf=/etc/resolv.conf


### PR DESCRIPTION
The sleep of 120 seconds when not having a vpn.crt file is completely unnecessary. There are config files which come with the certificate integrated already (eg. [AzireVPN-SE.ovpn](
Source https://www.azirevpn.com/dl/AzireVPN-SE.ovpn)).
Also, if we don't have a vpn.conf file, the VPN is not gonna be able to boot up, and therefore waiting two minutes to run the VPN client (which is obviously gonna fail) is unnecessary, too. Instead, we should rather exit with exit code 1, which means error. If someone wants to know on what it failed, he can either read the README again, or do `docker logs vpn`.