### PR TITLE
Switch to debian:stretch-slim to trim container weight

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:stretch-slim
 MAINTAINER David Personette <dperson@gmail.com>
 
 # Install openvpn


### PR DESCRIPTION
Switching to `debian:stretch-slim` is functionally equivalent to `debian:stretch` however the final container weight is 50Mb smaller.

```text
REPOSITORY            TAG                 IMAGE ID            CREATED             SIZE
ovpns                 latest              820e8cdb503a        7 minutes ago       66 MB
ovpn                  latest              1eeaced7c29c        9 minutes ago       110 MB
```