### PR TITLE
Fix support for ovpn files

### DIFF
--- a/openvpn.sh
+++ b/openvpn.sh
@@ -23,10 +23,10 @@ auth="$dir/vpn.cert_auth"
 conf="$dir/vpn.conf"
 cert="$dir/vpn-ca.crt"
 file="$dir/.firewall"
-[[ -f $conf ]] || { [[ $(echo $dir/*.{conf,ovpn} | wc -w) -eq 1 ]] &&
-            conf=echo $dir/*.{conf,ovpn}; }
-[[ -f $cert ]] || { [[ $(echo $dir/*.cert | wc -w) -eq 1 ]] &&
-            cert=echo $dir/*.cert; }
+[[ -f $conf ]] || { [[ $(ls $dir/. | egrep '\.(conf|ovpn)$' | wc -w ) -eq 1 ]] &&
+            conf="$dir/$(ls $dir/. | egrep '\.(conf|ovpn)$')"; }
+[[ -f $cert ]] || { [[ $(ls $dir/. | egrep '\.ce?rt$' | wc -w) -eq 1 ]] &&
+            cert="$dir/$(ls $dir/. | egrep '\.ce?rt$')"; }
 
 ### cert_auth: setup auth passwd for accessing certificate
 # Arguments:


### PR DESCRIPTION
This fixes the support for ovpn files.  The prior method would never work, because echo *.{conf,ovpn) always results in two entries. *.conf or the resolved conf if one or more files exist, and *.ovpn or the resolve ovpn files if one or more exist.  This version resolves the issue by listing all files in the directory, and egrep filters the results to all *.conf or *.ovpn files.  If there is just one (total) then it is assigned.  The same was done for the crt/cert files.