### PR TITLE
Update Dockerfile.armhf

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,1 +1,22 @@
 FROM armhf/debian:stretch
+
+RUN apt-get update -qq && \
+    apt-get install -qqy --no-install-recommends iptables openvpn procps \
+                $(apt-get -s dist-upgrade|awk '/^Inst.*ecurity/ {print $2}') &&\
+    echo '#!/usr/bin/env bash' >/sbin/resolvconf && \
+    echo 'conf=/etc/resolv.conf' >>/sbin/resolvconf && \
+    echo '[[ -e $conf.orig ]] || cp -p $conf $conf.orig' >>/sbin/resolvconf && \
+    echo 'if [[ "${1:-""}" == "-a" ]]; then' >>/sbin/resolvconf && \
+    echo '    cat >${conf}' >>/sbin/resolvconf && \
+    echo 'elif [[ "${1:-""}" == "-d" ]]; then' >>/sbin/resolvconf && \
+    echo '    cat $conf.orig >$conf' >>/sbin/resolvconf && \
+    echo 'fi' >>/sbin/resolvconf && \
+    chmod +x /sbin/resolvconf && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* && \
+    addgroup --system vpn
+COPY openvpn.sh /usr/bin/
+
+VOLUME ["/vpn"]
+
+ENTRYPOINT ["openvpn.sh"]


### PR DESCRIPTION
I might have misunderstood something about the `Dockerfile.armhf` but i didn't get why it was empty.
Launching am image builded from this Dockerfile result in a connection not being handled by the VPN. So i decided to add instructions to build the openvpn image properly.