### PR TITLE
Fix initialization/configuration failures when using ovpn file

### DIFF
--- a/openvpn.sh
+++ b/openvpn.sh
@@ -23,10 +23,10 @@ auth="$dir/vpn.cert_auth"
 conf="$dir/vpn.conf"
 cert="$dir/vpn-ca.crt"
 file="$dir/.firewall"
-[[ -f $conf ]] || { [[ $(ls $dir/*.{conf,ovpn} 2>&- | wc -w) -eq 1 ]] &&
-            conf=$(ls $dir/*.{conf,ovpn} 2>&-); }
-[[ -f $cert ]] || { [[ $(ls $dir/*.crt 2>&- | wc -w) -eq 1 ]] &&
-            cert=$(ls $dir/*.crt 2>&-); }
+[[ -f $conf ]] || { [[ $(ls $dir/. | egrep '\.(conf|ovpn)$' | wc -w ) -eq 1 ]] &&
+            conf="$dir/$(ls $dir/. | egrep '\.(conf|ovpn)$')"; }
+[[ -f $cert ]] || { [[ $(ls $dir/. | egrep '\.ce?rt$' | wc -w) -eq 1 ]] &&
+            cert="$dir/$(ls $dir/. | egrep '\.ce?rt$')"; }
 
 ### cert_auth: setup auth passwd for accessing certificate
 # Arguments:


### PR DESCRIPTION
because of the nature of the ls command with wildcards, configurations like mine that use the .ovpn file fail to work unless I also create the conf file.  This fix allows the ovpn file to be used without a complementing conf file.  

The way the wildcard parser works, the logic to override the conf file fails, because the ls command results in at least 1 file not found, and thus the && true conditional execution event cannot run.