### PR TITLE
add --cd to openvpn command line

### DIFF
--- a/openvpn.sh
+++ b/openvpn.sh
@@ -245,5 +245,5 @@ else
     [[ -e $conf ]] || { echo "ERROR: VPN not configured!"; sleep 120; }
     [[ -e $cert ]] || grep -q '<ca>' $conf ||
         { echo "ERROR: VPN CA cert missing!"; sleep 120; }
-    exec sg vpn -c "openvpn --config $conf"
+    exec sg vpn -c "openvpn --config $conf --cd $dir"
 fi


### PR DESCRIPTION
I added --cd to command line so that config files in the /vpn directory can reference other files with relative paths.