### PR TITLE
Cope with subdirectories that may contain opvn configs

### DIFF
--- a/openvpn.sh
+++ b/openvpn.sh
@@ -206,10 +206,10 @@ conf="$dir/vpn.conf"
 cert="$dir/vpn-ca.crt"
 route="$dir/.firewall"
 route6="$dir/.firewall6"
-[[ -f $conf ]] || { [[ $(ls $dir/*|egrep '\.(conf|ovpn)$' 2>&-|wc -w) -eq 1 ]]&&
-            conf="$(ls $dir/* | egrep '\.(conf|ovpn)$' 2>&-)"; }
-[[ -f $cert ]] || { [[ $(ls $dir/* | egrep '\.ce?rt$' 2>&- | wc -w) -eq 1 ]] &&
-            cert="$(ls $dir/* | egrep '\.ce?rt$' 2>&-)"; }
+[[ -f $conf ]] || { [[ $(ls -d $dir/*|egrep '\.(conf|ovpn)$' 2>&-|wc -w) -eq 1 ]]&&
+            conf="$(ls -d $dir/* | egrep '\.(conf|ovpn)$' 2>&-)"; }
+[[ -f $cert ]] || { [[ $(ls -d $dir/* | egrep '\.ce?rt$' 2>&- | wc -w) -eq 1 ]] &&
+            cert="$(ls -d $dir/* | egrep '\.ce?rt$' 2>&-)"; }
 
 while getopts ":hc:df:p:R:r:v:" opt; do
     case "$opt" in


### PR DESCRIPTION
I had an issue getting this container working when I'd unzipped all the ovpn configs from my VPN provider under the /vpn mount and then symlinked the one I wanted. This check for the file ended up finding all the configs in subdirectories and preventing the VPN from starting. This seems to fix the issue.