### PR TITLE
Fixed check for CA cert option in config.

### DIFF
--- a/openvpn.sh
+++ b/openvpn.sh
@@ -253,7 +253,7 @@ else
     mkdir -p /dev/net
     [[ -c /dev/net/tun ]] || mknod -m 0666 /dev/net/tun c 10 200
     [[ -e $conf ]] || { echo "ERROR: VPN not configured!"; sleep 120; }
-    [[ -e $cert ]] || grep -q '<ca>' $conf ||
+    [[ -e $cert ]] || grep -q -E '^[[:space:]]*(<ca>|ca[[:space:]]+)' $conf ||
         { echo "ERROR: VPN CA cert missing!"; sleep 120; }
     exec sg vpn -c "openvpn --cd $dir --config $conf \
                 ${MSS:+--fragment $MSS --mssfix}"


### PR DESCRIPTION
The expression for testing whether a CA certificate is specified in the
VPN configuration was broken, preventing the usage of exiting config
files referencing a CA certificate.