### PR TITLE
Prevent dns() sed pattern corrupting certs/keys.

### DIFF
--- a/openvpn.sh
+++ b/openvpn.sh
@@ -38,7 +38,7 @@ cert_auth() { local passwd="$1"
 #   none)
 # Return: conf file that uses VPN provider's DNS resolvers
 dns() {
-    sed -i '/down\|up/d; /resolv-*conf/d; /script-security/d' $conf
+    sed -i '/down[[:space:]]\|up[[:space:]]/d; /resolv-*conf/d; /script-security/d' $conf
     echo "# This updates the resolvconf with dns settings" >>$conf
     echo "script-security 2" >>$conf
     echo "up /etc/openvpn/up.sh" >>$conf


### PR DESCRIPTION
If any line in a cert/key in an .ovpn file starts with "up" (or potentially "down") sed will delete it, resulting in corrupt certs. This patch requires "up" to be followed by a space, so it should only match the intended lines.