### PR TITLE
Update iptables to drop incoming traffic

### DIFF
--- a/openvpn.sh
+++ b/openvpn.sh
@@ -68,7 +68,7 @@ configure_default_rules() {
   ${IPT} -X
   # Default filter policy
   ${IPT} -P INPUT DROP
-  ${IPT} -P INPUT DROP
+  ${IPT} -P OUTPUT DROP
   ${IPT} -P FORWARD DROP
   # Accept on localhost
   ${IPT} -A INPUT -i lo -j ACCEPT

--- a/openvpn.sh
+++ b/openvpn.sh
@@ -48,6 +48,7 @@ dns() {
 
 allow_only_vpn_dns () {
     local IPT=$1
+    # Will generate the hex string for DNS request in the form |03|www|06|google|03|com including zero padding
     remotes=$(egrep "^remote" $conf | awk '{print $2}' | awk -F '.' '{b=""}{
                 for (i=1;i<=NF;i++) {
                     h=sprintf("%x", length($1));


### PR DESCRIPTION
This is the pull-request for the issue #189 which is dealing with the fact that currently all containers are exposed by the iptables configured at the moment.

Btw. this pull request includes the changes of @davebv pull request #190 

Most changes in this pull request have been made by @davebv a minor adjustment to DROP OUPUT traffic by default by myself (discussed here https://github.com/dperson/openvpn-client/issues/189#issuecomment-496296666)