### PR TITLE
Extend documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ container) when you launch the service in its container.
 
 ## Starting an OpenVPN client instance
 
+**If you have a working OpenVPN .ovpn/.conf-file:** 
+    
+    sudo cp /path/to/service.ovpn /some/path/service.ovpn
+    sudo docker run -it --cap-add=NET_ADMIN --device /dev/net/tun --name vpn \
+                -v /some/path:/vpn -d dperson/openvpn-client
+
+Please note that you may only have one .ovpn/.conf-file in /some/path/.
+
+**If you only have an OpenVPN .crt-file:**
+                
     sudo cp /path/to/vpn.crt /some/path/vpn-ca.crt
     sudo docker run -it --cap-add=NET_ADMIN --device /dev/net/tun --name vpn \
                 -v /some/path:/vpn -d dperson/openvpn-client \

--- a/README.md
+++ b/README.md
@@ -207,6 +207,27 @@ get from your VPN. You'll need to add the `--dns` command line option to the
                 --dns 8.8.4.4 -v /some/path:/vpn -d dperson/openvpn-client \
                 -v 'vpn.server.name;username;password'
 
+### Sample docker-compose.yaml
+
+   version: "3"
+
+   services:
+     vpn:
+       container_name: "vpn"
+      environment:
+        TZ: 'Europe/Berlin'
+      volumes:
+        - /some/path:/vpn
+      dns:
+        - 8.8.8.8 
+      cap_add:
+        - NET_ADMIN
+      devices:
+        - '/dev/net/tun'
+      command: -f '' -v 'vpn.server.name;username;password' 
+      image: dperson/openvpn-client 
+      restart: unless-stopped
+
 # User Feedback
 
 ## Issues

--- a/README.md
+++ b/README.md
@@ -209,24 +209,23 @@ get from your VPN. You'll need to add the `--dns` command line option to the
 
 ### Sample docker-compose.yaml
 
-   version: "3"
-
-   services:
-     vpn:
-       container_name: "vpn"
-      environment:
-        TZ: 'Europe/Berlin'
-      volumes:
-        - /some/path:/vpn
-      dns:
-        - 8.8.8.8 
-      cap_add:
-        - NET_ADMIN
-      devices:
-        - '/dev/net/tun'
-      command: -f '' -v 'vpn.server.name;username;password' 
-      image: dperson/openvpn-client 
-      restart: unless-stopped
+    version: "3"
+    services:
+      vpn:
+        container_name: "vpn"
+       environment:
+         TZ: 'Europe/Berlin'
+       volumes:
+         - /some/path:/vpn
+       dns:
+         - 8.8.8.8 
+       cap_add:
+         - NET_ADMIN
+       devices:
+         - '/dev/net/tun'
+       command: -f '' -v 'vpn.server.name;username;password' 
+       image: dperson/openvpn-client 
+       restart: unless-stopped
 
 # User Feedback
 


### PR DESCRIPTION
This will extend the README.md-File to inlcude the already present but undocumented feature of using an existing .ovpn/.conf-file which for me was the easier option than changing the openvpn.sh to include options needed for anonie.com's VPN-servers.

Also included is a sample docker-compose-file.