### PR TITLE
env port forward add protocol

### DIFF
--- a/openvpn.sh
+++ b/openvpn.sh
@@ -261,7 +261,7 @@ route6="$dir/.firewall6"
 [[ "${ROUTE:-""}" ]] && return_route "$ROUTE"
 [[ "${VPN:-""}" ]] && eval vpn $(sed 's/^/"/; s/$/"/; s/;/" "/g' <<< $VPN)
 while read i; do
-    vpnportforward $(sed 's/^/"/; s/$/"/; s/;/" "/g' <<< $i)
+    eval vpnportforward $(sed 's/^/"/; s/$/"/; s/;/" "/g' <<< $i)
 done < <(env | awk '/^VPNPORT[0-9=_]/ {sub (/^[^=]*=/, "", $0); print}')
 
 while getopts ":hc:df:m:p:R:r:v:" opt; do

--- a/openvpn.sh
+++ b/openvpn.sh
@@ -261,7 +261,7 @@ route6="$dir/.firewall6"
 [[ "${ROUTE:-""}" ]] && return_route "$ROUTE"
 [[ "${VPN:-""}" ]] && eval vpn $(sed 's/^/"/; s/$/"/; s/;/" "/g' <<< $VPN)
 while read i; do
-    vpnportforward "$i"
+    vpnportforward $(sed 's/^/"/; s/$/"/; s/;/" "/g' <<< $i)
 done < <(env | awk '/^VPNPORT[0-9=_]/ {sub (/^[^=]*=/, "", $0); print}')
 
 while getopts ":hc:df:m:p:R:r:v:" opt; do


### PR DESCRIPTION
Allow using port forwadring format `<port>[;protocol]` in env.

Currently is not supported:
```
Try `iptables -h' or 'iptables --help' for more information.
iptables v1.8.3 (legacy): invalid port/service `55007;udp' specified
```

Even though docs says it should be `As above, setup port forwarding`.