### PR TITLE
add command line and env var to set vpn username and password 

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ the second container (that's what `--net=container:vpn` does).
         -c '<passwd>' Configure an authentication password to open the cert
                     required arg: '<passwd>'
                     <passwd> password to access the certificate file
+        -a '<user;password>' Configure authentication username and password
         -d          Use the VPN provider's DNS resolvers
         -f '[port]' Firewall rules so that only the VPN and DNS are allowed to
                     send internet traffic (IE if VPN is down it's offline)
@@ -145,6 +146,7 @@ ENVIRONMENT VARIABLES
  * `ROUTE` - As above, add a route to allow replies to your private network
  * `TZ` - Set a timezone, IE `EST5EDT`
  * `VPN` - As above, setup a VPN connection
+ * `VPN_AUTH` - As above, provide authentication to vpn server
  * `VPNPORT` - As above, setup port forwarding (See NOTE below)
  * `GROUPID` - Set the GID for the vpn
 
@@ -230,6 +232,14 @@ The vpn.conf should look like this:
 
     persist-key
     persist-tun
+
+### Run with openvpn client configuration and provided auth
+
+In case you want to use your client configuration in /vpn named vpn.conf 
+but adding your vpn user and password by command line
+
+    sudo docker run -it --cap-add=NET_ADMIN --device /dev/net/tun --name vpn \
+            -v /some/path:/vpn -d dperson/openvpn-client -a 'username;password'
 
 # User Feedback
 


### PR DESCRIPTION
* add command line and env var to set vpn username and password while using your own openvpn conf file

* usefull when you have ovpn file from your provider but with missing username and password that you just want to set in command line but without regenerate the configuration with arg `-v`

* new arg  `-a '<user;password>' `

* new env var `VPN_AUTH`

