### PR TITLE
Files management : Add option for specify vpn conf and ca cert files - use /tmp folder for generated or modified files

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ the second container (that's what `--net=container:vpn` does).
                     optional args:
                     [port] to use, instead of default
                     [proto] to use, instead of udp (IE, tcp)
+        -V '<[conf][;cert]>' Specify OpenVPN configuration and cert file
+                    required arg:
+                    optional args:
+                    [conf] file inside /vpn to use for openvpn configuration
+                    [cert] file inside /vpn to use as cert file with ca
 
     The 'command' (if provided and valid) will be run instead of openvpn
 
@@ -192,6 +197,16 @@ Or you can store it in the container:
                 -v 'vpn.server.name;username;password' tee /vpn/vpn-ca.crt \
                 >/dev/null
     sudo docker restart vpn
+
+### VPN select configuration files
+
+All files must be specified relative to `/vpn`
+
+    ls /some/path/myown-ca.crt
+    ls /some/path/myovpn.ovpn
+    sudo docker run -it --cap-add=NET_ADMIN --device /dev/net/tun --name vpn \
+                -v /some/path:/vpn -d dperson/openvpn-client \
+                -V 'myovpn.ovpn;myown-ca.crt'
 
 ### Firewall
 

--- a/README.md
+++ b/README.md
@@ -203,11 +203,27 @@ Or you can store it in the container:
 
 All files must be specified relative to `/vpn`
 
+Full configuration with vpn conf and cert ca file provided
+
     ls /some/path/myown-ca.crt
     ls /some/path/myovpn.ovpn
     sudo docker run -it --cap-add=NET_ADMIN --device /dev/net/tun --name vpn \
-                -v /some/path:/vpn -d dperson/openvpn-client \
+                -v /some/path:/vpn 
+                -e TZ=Europe/London -e DNS=1 -e "OTHER_ARGS=--redirect-gateway def1"
+                dperson/openvpn-client \
                 -V 'myovpn.ovpn;myown-ca.crt'
+
+
+Full configuration with only cert ca file provided. VPN conf will be generated
+
+    ls /some/path/myown-ca.crt
+    sudo docker run -it --cap-add=NET_ADMIN --device /dev/net/tun --name vpn \
+            -v /some/path:/vpn \
+            -e TZ=Europe/London -e DNS=1 -e "OTHER_ARGS=--redirect-gateway def1"
+            dperson/openvpn \
+            -v 'vpn.server.name;username;password'
+            -V ';myown-ca.crt'
+
 
 ### Firewall
 
@@ -229,6 +245,10 @@ get from your VPN. You'll need to add the `--dns` command line option to the
     sudo docker run -it --cap-add=NET_ADMIN --device /dev/net/tun --name vpn \
                 --dns 8.8.4.4 -v /some/path:/vpn -d dperson/openvpn-client \
                 -v 'vpn.server.name;username;password'
+
+### Use DNS of VPN Provider
+
+If you want to use dns server from your VPN provider use openvpn.sh `-d` or `DNS` env var
 
 ### Run with client certificates
 
@@ -261,11 +281,13 @@ The vpn.conf should look like this:
 
 ### Run with openvpn client configuration and provided auth
 
-In case you want to use your client configuration in /vpn named vpn.conf 
-but adding your vpn user and password by command line
+In case you want to use your own client configuration in /vpn named by default
+vpn.conf but adding your vpn user and password by command line
 
     sudo docker run -it --cap-add=NET_ADMIN --device /dev/net/tun --name vpn \
             -v /some/path:/vpn -d dperson/openvpn-client -a 'username;password'
+
+
 
 # User Feedback
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Running the following on your docker host should give you the correct network:
 
 **NOTE**: if you don't use the `-v` to configure your VPN, then you'll have to
 make sure that `redirect-gateway def1` is set, otherwise routing may not work.
+Or you could use -o option to pass it : `-o '--redirect-gateway def1'`
 
 **NOTE 2**: if you have a port you want to make available, you have to add the
 docker `-p` option to the VPN container. The network stack will be reused by
@@ -109,12 +110,17 @@ the second container (that's what `--net=container:vpn` does).
         -c '<passwd>' Configure an authentication password to open the cert
                     required arg: '<passwd>'
                     <passwd> password to access the certificate file
+        -a '<user;password>' Configure authentication username and password
         -d          Use the VPN provider's DNS resolvers
         -f '[port]' Firewall rules so that only the VPN and DNS are allowed to
                     send internet traffic (IE if VPN is down it's offline)
                     optional arg: [port] to use, instead of default
         -m '<mss>'  Maximum Segment Size <mss>
                     required arg: '<mss>'
+        -o '<args>' Allow to pass any arguments directly to openvpn
+            required arg: '<args>'
+            <args> could be any string matching openvpn arguments
+            i.e '--arg1 value --arg2 value'
         -p '<port>[;protocol]' Forward port <port>
                     required arg: '<port>'
                     optional arg: [protocol] to use instead of default (tcp)
@@ -137,15 +143,19 @@ the second container (that's what `--net=container:vpn` does).
 
 ENVIRONMENT VARIABLES
 
- * `CERT_AUTH` - As above, provide authentication to access certificate
- * `DNS` - As above, Use the VPN provider's DNS resolvers
- * `FIREWALL` - As above, setup firewall to disallow net access w/o the VPN
- * `MSS` - As above, set Maximum Segment Size
- * `ROUTE6` - As above, add a route to allow replies to your internal network
- * `ROUTE` - As above, add a route to allow replies to your private network
+ * `CERT_AUTH` - As above (-c) provide authentication to access certificate
+ * `DNS` - As above (-d) use the VPN provider's DNS resolvers
+ * `FIREWALL` - As above (-f) setup firewall to disallow net access w/o the VPN
+ * `CIPHER` - Set openvpn cipher option when generating conf file with -v
+ * `AUTH` - Set openvpn auth option when generating conf file with -v
+ * `MSS` - As above (-m) set Maximum Segment Size
+ * `OTHER_ARGS` - As above (-o) pass arguments directly to openvpn
+ * `ROUTE6` - As above (-R) add a route to allow replies to your private network
+ * `ROUTE` - As above (-r) add a route to allow replies to your private network
  * `TZ` - Set a timezone, IE `EST5EDT`
- * `VPN` - As above, setup a VPN connection
- * `VPNPORT` - As above, setup port forwarding (See NOTE below)
+ * `VPN` - As above (-v) setup a VPN connection
+ * `VPN_AUTH` - As above (-a) provide authentication to vpn server
+ * `VPNPORT` - As above (-p) setup port forwarding (See NOTE below)
  * `GROUPID` - Set the GID for the vpn
 
  **NOTE**: optionally supports additional variables starting with the same name,
@@ -164,6 +174,8 @@ Any of the commands can be run at creation with `docker run` or later with
                 -v 'vpn.server.name;username;password'
 
 ### VPN configuration
+
+**NOTE**: When using `-v` a vpn configuration is generated.
 
 In order to work you must provide VPN configuration and the certificate. You can
 use external storage for `/vpn`:
@@ -230,6 +242,14 @@ The vpn.conf should look like this:
 
     persist-key
     persist-tun
+
+### Run with openvpn client configuration and provided auth
+
+In case you want to use your client configuration in /vpn named vpn.conf 
+but adding your vpn user and password by command line
+
+    sudo docker run -it --cap-add=NET_ADMIN --device /dev/net/tun --name vpn \
+            -v /some/path:/vpn -d dperson/openvpn-client -a 'username;password'
 
 # User Feedback
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ the second container (that's what `--net=container:vpn` does).
                     optional args:
                     [port] to use, instead of default
                     [proto] to use, instead of udp (IE, tcp)
-        -V '<[conf][;cert]>' Specify OpenVPN configuration and cert file
+        -V '<[conf][;cert]>' Specify OpenVPN configuration and ca cert file
                     required arg:
                     optional args:
                     [conf] file inside /vpn to use for openvpn configuration
@@ -159,6 +159,7 @@ ENVIRONMENT VARIABLES
  * `ROUTE` - As above (-r) add a route to allow replies to your private network
  * `TZ` - Set a timezone, IE `EST5EDT`
  * `VPN` - As above (-v) setup a VPN connection
+ * `VPN_FILES` - As above (-V) specify configuration and ca cert file
  * `VPN_AUTH` - As above (-a) provide authentication to vpn server
  * `VPNPORT` - As above (-p) setup port forwarding (See NOTE below)
  * `GROUPID` - Set the GID for the vpn

--- a/openvpn.sh
+++ b/openvpn.sh
@@ -147,7 +147,6 @@ return_route() { local network="$1" gw="$(ip route |awk '/default/ {print $3}')"
 #   pass) password on VPN
 # Return: configured auth file
 vpn_auth() { local user="$1" pass="$2"
-
     echo "$user" >$auth
     echo "$pass" >>$auth
     chmod 0600 $auth
@@ -158,7 +157,11 @@ vpn_auth() { local user="$1" pass="$2"
 #   conf) openvpn configuration file
 #   cert) cert file with ca
 vpn_files() {
-    [[ "${1:-}" ]] && conf="$dir/$1"
+    if [[ "${1:-}" ]]; then
+        if [[ -f "$dir/$1" ]]; then
+            cp -f "$dir/$1" "$conf"
+        fi
+    fi
     [[ "${2:-}" ]] && cert="$dir/$2"
 }
 
@@ -326,8 +329,8 @@ while getopts ":hc:df:a:m:o:p:R:r:v:V:" opt; do
 done
 shift $(( OPTIND - 1 ))
 
-[[ "${do_dns:-""}" ]] || dns
-[[ "${do_cert_auth:-""}" ]] || cert_auth "${do_cert_auth}"
+[[ "${do_dns:-""}" ]] && dns
+[[ "${do_cert_auth:-""}" ]] && cert_auth "${do_cert_auth}"
 
 if [[ $# -ge 1 && -x $(which $1 2>&-) ]]; then
     exec "$@"

--- a/openvpn.sh
+++ b/openvpn.sh
@@ -141,6 +141,18 @@ return_route() { local network="$1" gw="$(ip route |awk '/default/ {print $3}')"
     [[ -e $route ]] && grep -q "^$network\$" $route || echo "$network" >>$route
 }
 
+### vpn_auth: configure authentication username and password
+# Arguments:
+#   user) user name on VPN
+#   pass) password on VPN
+# Return: configured auth file
+vpn_auth() { local user="$1" pass="$2"
+
+    echo "$user" >$auth
+    echo "$pass" >>$auth
+    chmod 0600 $auth
+}
+
 ### vpn: setup openvpn client
 # Arguments:
 #   server) VPN GW server
@@ -217,12 +229,17 @@ Options (fields in '[]' are optional, '<>' are required):
     -c '<passwd>' Configure an authentication password to open the cert
                 required arg: '<passwd>'
                 <passwd> password to access the certificate file
+    -a '<user;password>' Configure authentication username and password
     -d          Use the VPN provider's DNS resolvers
     -f '[port]' Firewall rules so that only the VPN and DNS are allowed to
                 send internet traffic (IE if VPN is down it's offline)
                 optional arg: [port] to use, instead of default
     -m '<mss>'  Maximum Segment Size <mss>
                 required arg: '<mss>'
+    -o '<args>' Allow to pass any arguments directly to openvpn
+                required arg: '<args>'
+                <args> could be any string matching openvpn arguments
+                i.e '--arg1 value --arg2 value'
     -p '<port>[;protocol]' Forward port <port>
                 required arg: '<port>'
                 optional arg: [protocol] to use instead of default (tcp)
@@ -258,6 +275,7 @@ route6="$dir/.firewall6"
 [[ -f $cert ]] || { [[ $(ls -d $dir/* | egrep '\.ce?rt$' 2>&- | wc -w) -eq 1 \
             ]] && cert="$(ls -d $dir/* | egrep '\.ce?rt$' 2>&-)"; }
 
+[[ "${VPN_AUTH:-""}" ]] && eval vpn_auth $(sed 's/^/"/; s/$/"/; s/;/" "/g' <<< $VPN_AUTH)
 [[ "${CERT_AUTH:-""}" ]] && cert_auth "$CERT_AUTH"
 [[ "${DNS:-""}" ]] && dns
 [[ "${GROUPID:-""}" =~ ^[0-9]+$ ]] && groupmod -g $GROUPID -o vpn
@@ -273,13 +291,16 @@ while read i; do
     eval vpnportforward $(sed 's/^/"/; s/$/"/; s/;/" "/g' <<< $i)
 done < <(env | awk '/^VPNPORT[0-9=_]/ {sub (/^[^=]*=/, "", $0); print}')
 
-while getopts ":hc:df:m:p:R:r:v:" opt; do
+while getopts ":hc:df:a:m:o:p:R:r:v:" opt; do
     case "$opt" in
         h) usage ;;
+        a) eval vpn_auth $(sed 's/^/"/; s/$/"/; s/;/" "/g' <<< $OPTARG)
+           AUTH_COMMAND="--auth-user-pass $auth" ;;
         c) cert_auth "$OPTARG" ;;
         d) dns ;;
         f) firewall "$OPTARG"; touch $route $route6 ;;
         m) MSS="$OPTARG" ;;
+        o) OTHER_ARGS="$OPTARG" ;;
         p) eval vpnportforward $(sed 's/^/"/; s/$/"/; s/;/" "/g' <<< $OPTARG) ;;
         R) return_route6 "$OPTARG" ;;
         r) return_route "$OPTARG" ;;
@@ -303,6 +324,6 @@ else
     [[ -e $conf ]] || { echo "ERROR: VPN not configured!"; sleep 120; }
     [[ -e $cert ]] || grep -Eq '^ *(<ca>|ca +)' $conf ||
         { echo "ERROR: VPN CA cert missing!"; sleep 120; }
-    exec sg vpn -c "openvpn --cd $dir --config $conf \
-                ${MSS:+--fragment $MSS --mssfix}"
+    exec sg vpn -c "openvpn --cd $dir --config $conf ${AUTH_COMMAND:-} \
+               ${OTHER_ARGS:-} ${MSS:+--fragment $MSS --mssfix}"
 fi

--- a/openvpn.sh
+++ b/openvpn.sh
@@ -303,7 +303,10 @@ route6="$dir/.firewall6"
 [[ -f $cert ]] || { [[ $(ls -d $dir/* | egrep '\.ce?rt$' 2>&- | wc -w) -eq 1 \
             ]] && cert="$(ls -d $dir/* | egrep '\.ce?rt$' 2>&-)"; }
 
-[[ "${VPN_AUTH:-""}" ]] && eval vpn_auth $(sed 's/^/"/; s/$/"/; s/;/" "/g' <<< $VPN_AUTH)
+if [[ "${VPN_AUTH:-""}" ]]; then
+    eval vpn_auth $(sed 's/^/"/; s/$/"/; s/;/" "/g' <<< $VPN_AUTH)
+    AUTH_COMMAND="--auth-user-pass $auth"
+fi
 [[ "${CERT_AUTH:-""}" ]] && do_cert_auth="$CERT_AUTH"
 [[ "${DNS:-""}" ]] && do_dns="1"
 [[ "${GROUPID:-""}" =~ ^[0-9]+$ ]] && groupmod -g $GROUPID -o vpn

--- a/openvpn.sh
+++ b/openvpn.sh
@@ -304,6 +304,7 @@ while read i; do
     return_route "$i"
 done < <(env | awk '/^ROUTE[=_]/ {sub (/^[^=]*=/, "", $0); print}')
 [[ "${VPN:-""}" ]] && eval vpn $(sed 's/^/"/; s/$/"/; s/;/" "/g' <<< $VPN)
+[[ "${VPN_FILES:-""}" ]] && eval vpn_files $(sed 's/^/"/; s/$/"/; s/;/" "/g' <<< $VPN_FILES)
 while read i; do
     eval vpnportforward $(sed 's/^/"/; s/$/"/; s/;/" "/g' <<< $i)
 done < <(env | awk '/^VPNPORT[0-9=_]/ {sub (/^[^=]*=/, "", $0); print}')


### PR DESCRIPTION
* add one option '-V' to specify our conf file and/or aour ca-cert file instead of generating it or have it with hardcoded file name

```


    -V '<[conf][;cert]>' Specify OpenVPN configuration and cert file
                required arg:
                optional args:
                [conf] file inside /vpn to use for openvpn configuration
                [cert] file inside /vpn to use as cert file with ca
```


* often when using a vpn provider we can download an archive of ovpn files with a lof of files. With this option and when mounting this folder into /vpn, we can choose which files to use without renaming it to vpn.conf (or withour deleting all files but one)

* NOTE : this is the same PR than #267 but with 
** a fix for dns, cert_auth settings and vpn conf generation order
** add a VPN_FILES env var matching `-V` option
** a fix to copy user file instead of modify it
** use /tmp folder to store provided or modified files to solve any CHOWN related issue
