### PR TITLE
add -V and VPN_FILES for specify your own conf and ca cert files

### DIFF
--- a/openvpn.sh
+++ b/openvpn.sh
@@ -298,8 +298,7 @@ route6="$dir/.firewall6"
 [[ -f $cert ]] || { [[ $(ls -d $dir/* | egrep '\.ce?rt$' 2>&- | wc -w) -eq 1 \
             ]] && cert="$(ls -d $dir/* | egrep '\.ce?rt$' 2>&-)"; }
 
-[[ "${VPN_AUTH:-""}" ]] && eval vpn_auth $(sed 's/^/"/; s/$/"/; s/;/" "/g' <<< \ 
-            $VPN_AUTH)
+[[ "${VPN_AUTH:-""}" ]] && eval vpn_auth $(sed 's/^/"/; s/$/"/; s/;/" "/g' <<< $VPN_AUTH)
 [[ "${CERT_AUTH:-""}" ]] && do_cert_auth="$CERT_AUTH"
 [[ "${DNS:-""}" ]] && do_dns="1"
 [[ "${GROUPID:-""}" =~ ^[0-9]+$ ]] && groupmod -g $GROUPID -o vpn


### PR DESCRIPTION
* This PR is a split of previous PR #269 without isolating files in /tmp which will be made in another PR

* MAIN CHANGE :

add one option '-V' and `VPN_FILES` env var to specify our conf file and/or aour ca-cert file instead of generating it or have it with hardcoded file name

```
 -V '<[conf][;cert]>' Specify OpenVPN configuration and cert file
                required arg:
                optional args:
                [conf] file inside /vpn to use for openvpn configuration
                [cert] file inside /vpn to use as cert file with ca
```

* EXPLANATION :

Often when using a vpn provider we can download an archive of ovpn files with a lof of files. 
With this option and when mounting this folder into /vpn, we can choose which files to use without renaming it to vpn.conf or without splitting each conf files in a seprate folder

* MORE EXPLANATION :

Majority of VPN provider provides .ovpn files with various files names belonging to the destination (amsterdam, zurich, etc..).
Changing output is just a matter of selecting right file.
When using your container changing output needs to separate each files in a separate folder AND changing mounted volume.
With `-V` or `VPN_FILES` it becomes only a matter of changing an env var.

So this change is about fixing `-v` option which cannot manage this, by adding another similar option `-V`.
`-v` is for generating conf or try to autodetect conf (if there is only one conf available)
`-V` is for providing our own specific conf

Note that we can combine the usage of -v and -V alltogether to specify only cert files.

I dont think it was the right way to add this feature in existing `vpn` function

