### PR TITLE
isolate files in tmp folder

### DIFF
--- a/openvpn.sh
+++ b/openvpn.sh
@@ -24,6 +24,7 @@ set -o nounset                              # Treat unset variables as an error
 # Return: conf file that supports certificate authentication
 cert_auth() { local passwd="$1"
     grep -q "^${passwd}\$" $cert_auth || {
+        cert_auth="/tmp/vpn.cert_auth"
         echo "$passwd" >$cert_auth
     }
     chmod 0600 $cert_auth
@@ -147,6 +148,7 @@ return_route() { local network="$1" gw="$(ip route |awk '/default/ {print $3}')"
 #   pass) password on VPN
 # Return: configured auth file
 vpn_auth() { local user="$1" pass="$2"
+    auth="/tmp/vpn.auth"
     echo "$user" >$auth
     echo "$pass" >>$auth
     chmod 0600 $auth
@@ -164,6 +166,9 @@ vpn_auth() { local user="$1" pass="$2"
 # Return: configured .ovpn file
 vpn() { local server="$1" user="$2" pass="$3" port="${4:-1194}" proto=${5:-udp}\
             i pem="$(\ls $dir/*.pem 2>&-)"
+
+    conf="/tmp/vpn.conf"
+    auth="/tmp/vpn.auth"
 
     echo "client" >$conf
     echo "dev tun" >>$conf
@@ -271,6 +276,8 @@ conf="$dir/vpn.conf"
 cert="$dir/vpn-ca.crt"
 route="$dir/.firewall"
 route6="$dir/.firewall6"
+[[ -e $route ]] || route="/tmp/.firewall"
+[[ -e $route6 ]] || route="/tmp/.firewall6"
 [[ -f $conf ]] || { [[ $(ls -d $dir/*|egrep '\.(conf|ovpn)$' 2>&-|wc -w) -eq 1 \
             ]] && conf="$(ls -d $dir/* | egrep '\.(conf|ovpn)$' 2>&-)"; }
 [[ -f $cert ]] || { [[ $(ls -d $dir/* | egrep '\.ce?rt$' 2>&- | wc -w) -eq 1 \


### PR DESCRIPTION
* This PR is a split of previous PR #269 about isolating files in /tmp

* This change is about using /tmp folder instead of /vpn only for existing files or generated files

* So we do not modify original files like vpn.conf by adding some stuff by modifying it !
* As another improvment too it solve unix permission problemes when for example we generate a vpn.conf file with root user

* NOTE : if PR #276 is merged too with this one, so another PR #278 should me merged two to isolates files specified by user