### PR TITLE
Fix DNS leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,7 @@ Running the following on your docker host should give you the correct network:
                 -v /some/path:/vpn -d dperson/openvpn-client \
                 -r 192.168.1.0/24 -v 'vpn.server.name;username;password'
 
-**NOTE**: if you don't use the `-v` to configure your VPN, then you'll have to
-make sure that `redirect-gateway def1` is set, otherwise routing may not work.
-Or you could use -o option to pass it : `-o '--redirect-gateway def1'`
-
-**NOTE 2**: if you have a port you want to make available, you have to add the
+**NOTE**: if you have a port you want to make available, you have to add the
 docker `-p` option to the VPN container. The network stack will be reused by
 the second container (that's what `--net=container:vpn` does).
 

--- a/openvpn.sh
+++ b/openvpn.sh
@@ -21,28 +21,32 @@ set -o nounset                              # Treat unset variables as an error
 ### cert_auth: setup auth passwd for accessing certificate
 # Arguments:
 #   passwd) Password to access the cert
-# Return: conf file that supports certificate authentication
+# Return: openvpn argument to support certificate authentication
 cert_auth() { local passwd="$1"
     grep -q "^${passwd}\$" $cert_auth || {
         echo "$passwd" >$cert_auth
     }
     chmod 0600 $cert_auth
-    grep -q "^askpass ${cert_auth}\$" $conf || {
-        sed -i '/^askpass[[:space:]]/d' $conf
-        echo "askpass $cert_auth" >>$conf
-    }
+    ext_args+=("--askpass $cert_auth")
 }
 
 ### dns: setup openvpn client DNS
 # Arguments:
 #   none)
-# Return: conf file that uses VPN provider's DNS resolvers
+# Return: openvpn arguments to use VPN provider's DNS resolvers
 dns() {
-    sed -i '/^\(down\|up\|#.*resolv-*conf\|script-security\)[[:space:]]/d' $conf
-    echo "# This updates the resolvconf with dns settings" >>$conf
-    echo "script-security 2" >>$conf
-    echo "up /etc/openvpn/up.sh" >>$conf
-    echo "down /etc/openvpn/down.sh" >>$conf
+    ext_args+=('--up /etc/openvpn/up.sh')
+    ext_args+=('--down /etc/openvpn/down.sh')
+}
+
+### filter_embedded_dns: iptables to filter embedded DNS requests
+# Arguments:
+#   none)
+# Return: openvpn arguments to restrict embedded DNS requests
+filter_embedded_dns() {
+    ext_args+=("--route-up '/sbin/iptables -A OUTPUT -d 127.0.0.11 -j ACCEPT'")
+    ext_args+=('--route-pre-down')
+    ext_args+=("'/bin/sh -c \"iptables -D OUTPUT -d 127.0.0.11 -j ACCEPT\"'")
 }
 
 ### firewall: firewall all output not DNS/VPN that's not over the VPN connection
@@ -79,11 +83,11 @@ firewall() { local port="${1:-1194}" docker_network="$(ip -o addr show dev eth0|
     ip6tables -A OUTPUT -o tap+ -j ACCEPT 2>/dev/null
     ip6tables -A OUTPUT -o tun+ -j ACCEPT 2>/dev/null
     ip6tables -A OUTPUT -d ${docker6_network} -j ACCEPT 2>/dev/null
-    ip6tables -A OUTPUT -p udp -m udp --dport 53 -j ACCEPT 2>/dev/null
     ip6tables -A OUTPUT -p tcp -m owner --gid-owner vpn -j ACCEPT 2>/dev/null &&
     ip6tables -A OUTPUT -p udp -m owner --gid-owner vpn -j ACCEPT 2>/dev/null||{
         ip6tables -A OUTPUT -p tcp -m tcp --dport $port -j ACCEPT 2>/dev/null
-        ip6tables -A OUTPUT -p udp -m udp --dport $port -j ACCEPT 2>/dev/null; }
+        ip6tables -A OUTPUT -p udp -m udp --dport $port -j ACCEPT 2>/dev/null
+        ip6tables -A OUTPUT -p udp -m udp --dport 53 -j ACCEPT 2>/dev/null; }
     iptables -F
     iptables -X
     iptables -P INPUT DROP
@@ -97,15 +101,19 @@ firewall() { local port="${1:-1194}" docker_network="$(ip -o addr show dev eth0|
     iptables -A FORWARD -d ${docker_network} -j ACCEPT
     iptables -A FORWARD -s ${docker_network} -j ACCEPT
     iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
-    iptables -A OUTPUT -o lo -j ACCEPT
+    iptables -A OUTPUT -o lo ! -d 127.0.0.11 -j ACCEPT
     iptables -A OUTPUT -o tap+ -j ACCEPT
     iptables -A OUTPUT -o tun+ -j ACCEPT
     iptables -A OUTPUT -d ${docker_network} -j ACCEPT
-    iptables -A OUTPUT -p udp -m udp --dport 53 -j ACCEPT
     iptables -A OUTPUT -p tcp -m owner --gid-owner vpn -j ACCEPT 2>/dev/null &&
     iptables -A OUTPUT -p udp -m owner --gid-owner vpn -j ACCEPT || {
         iptables -A OUTPUT -p tcp -m tcp --dport $port -j ACCEPT
-        iptables -A OUTPUT -p udp -m udp --dport $port -j ACCEPT; }
+        iptables -A OUTPUT -p udp -m udp --dport $port -j ACCEPT
+        iptables -A OUTPUT -p udp -m udp --dport 53 -j ACCEPT; }
+    if grep -Fq "127.0.0.11" /etc/resolv.conf; then
+        iptables -A OUTPUT -d 127.0.0.11 -m owner --gid-owner vpn -j ACCEPT || 
+            iptables -A OUTPUT -d 127.0.0.11 -j ACCEPT
+        iptables -A OUTPUT -p udp -m udp --dport 53 -j ACCEPT; fi
     iptables -t nat -A POSTROUTING -o tap+ -j MASQUERADE
     iptables -t nat -A POSTROUTING -o tun+ -j MASQUERADE
     [[ -s $route6 ]] && for net in $(cat $route6); do return_route6 $net; done
@@ -151,7 +159,7 @@ vpn_auth() { local user="$1" pass="$2"
     echo "$pass" >>$auth
     chmod 0600 $auth
 
-    export AUTH_COMMAND="--auth-user-pass $auth"
+    ext_args+=("--auth-user-pass $auth")
 }
 
 ### vpn: setup openvpn client
@@ -181,19 +189,15 @@ vpn() { local server="$1" user="$2" pass="$3" port="${4:-1194}" proto=${5:-udp}\
     [[ "${AUTH:-""}" ]] && echo "auth $AUTH" >>$conf
     echo "tls-client" >>$conf
     echo "remote-cert-tls server" >>$conf
-    echo "auth-user-pass $auth" >>$conf
     echo "comp-lzo" >>$conf
     echo "verb 1" >>$conf
     echo "reneg-sec 0" >>$conf
-    echo "redirect-gateway def1" >>$conf
     echo "disable-occ" >>$conf
     echo "fast-io" >>$conf
     echo "ca $cert" >>$conf
     [[ $(wc -w <<< $pem) -eq 1 ]] && echo "crl-verify $pem" >>$conf
 
-    echo "$user" >$auth
-    echo "$pass" >>$auth
-    chmod 0600 $auth
+    vpn_auth "$user" "$pass"
 
     [[ "${FIREWALL:-""}" || -e $route6 || -e $route ]] &&
         [[ "${4:-""}" ]] && firewall $port
@@ -206,13 +210,13 @@ vpn() { local server="$1" user="$2" pass="$3" port="${4:-1194}" proto=${5:-udp}\
 # Return: configured NAT rule
 vpnportforward() { local port="$1" protocol="${2:-tcp}"
     ip6tables -t nat -A OUTPUT -i tun0 -p $protocol --dport $port -j DNAT \
-                --to-destination ::11:$port 2>/dev/null
+                --to-destination ::111:$port 2>/dev/null
     ip6tables -A INPUT -p $protocol -m $protocol --dport $port -j ACCEPT \
                 2>/dev/null
     ip6tables -A FORWARD -i tun0 -p $protocol -m $protocol --dport $port -j \
                 ACCEPT 2>/dev/null
     iptables -t nat -A OUTPUT -i tun0 -p $protocol --dport $port -j DNAT \
-                --to-destination 127.0.0.11:$port
+                --to-destination 127.0.0.111:$port
     iptables -A INPUT -p $protocol -m $protocol --dport $port -j ACCEPT
     iptables -A FORWARD -i tun0 -p $protocol -m $protocol --dport $port -j \
                 ACCEPT
@@ -271,13 +275,14 @@ conf="$dir/vpn.conf"
 cert="$dir/vpn-ca.crt"
 route="$dir/.firewall"
 route6="$dir/.firewall6"
+ext_args=('--script-security 2' '--redirect-gateway def1')
 [[ -f $conf ]] || { [[ $(ls -d $dir/*|egrep '\.(conf|ovpn)$' 2>&-|wc -w) -eq 1 \
             ]] && conf="$(ls -d $dir/* | egrep '\.(conf|ovpn)$' 2>&-)"; }
 [[ -f $cert ]] || { [[ $(ls -d $dir/* | egrep '\.ce?rt$' 2>&- | wc -w) -eq 1 \
             ]] && cert="$(ls -d $dir/* | egrep '\.ce?rt$' 2>&-)"; }
 
-[[ "${VPN_AUTH:-""}" ]] && eval vpn_auth $(sed 's/^/"/; s/$/"/; s/;/" "/g' <<< \
-            $VPN_AUTH)
+[[ "${VPN_AUTH:-""}" ]] &&
+    eval vpn_auth $(sed 's/^/"/; s/$/"/; s/;/" "/g' <<< $VPN_AUTH)
 [[ "${CERT_AUTH:-""}" ]] && cert_auth "$CERT_AUTH"
 [[ "${DNS:-""}" ]] && dns
 [[ "${GROUPID:-""}" =~ ^[0-9]+$ ]] && groupmod -g $GROUPID -o vpn
@@ -312,6 +317,8 @@ while getopts ":hc:df:a:m:o:p:R:r:v:" opt; do
 done
 shift $(( OPTIND - 1 ))
 
+filter_embedded_dns
+
 if [[ $# -ge 1 && -x $(which $1 2>&-) ]]; then
     exec "$@"
 elif [[ $# -ge 1 ]]; then
@@ -325,6 +332,6 @@ else
     [[ -e $conf ]] || { echo "ERROR: VPN not configured!"; sleep 120; }
     [[ -e $cert ]] || grep -Eq '^ *(<ca>|ca +)' $conf ||
         { echo "ERROR: VPN CA cert missing!"; sleep 120; }
-    exec sg vpn -c "openvpn --cd $dir --config $conf ${AUTH_COMMAND:-} \
+    exec sg vpn -c "openvpn --cd $dir --config $conf ${ext_args[*]} \
                ${OTHER_ARGS:-} ${MSS:+--fragment $MSS --mssfix}"
 fi


### PR DESCRIPTION
I've noticed, that you allowed DNS requests from every source:
`iptables -A OUTPUT -p udp -m udp --dport 53 -j ACCEPT`
This is probably due to the fact, that DNS requests from the embedded DNS can't be filtered by _--gid-owner_, because the eDNS runs as gid 0.
When you leave the 53 port open, all DNS requests from containers attached to the vpn network will bypass vpn protection before the vpn connection is established or if the vpn is down.

**Background Information on the embedded DNS:**
When running a container on the default bridge network, the dns specified with the _--dns_ argument, or by default the hosts DNS are inserted in _/etc/resolv.conf_ and other container hostnames are resolved over _/etc/hosts_ entries.
If you use a custom network, docker runs an embedded DNS in your container, reachable at _127.0.0.11_
```
# cat /etc/resolv.conf
nameserver 127.0.0.11
options ndots:0
```
Container hostnames are now resolved over this eDNS, which means that overwriting the _/etc/resolv.conf_ with the vpn dns option will break container resolving.

```
# iptables -nvL -t nat  
.....  
Chain DOCKER_OUTPUT (1 references)  
 pkts bytes target     prot opt in     out     source               destination  
    0     0 DNAT       tcp  --  *      *       0.0.0.0/0            127.0.0.11           tcp dpt:53 to:127.0.0.11:45997  
    0     0 DNAT       udp  --  *      *       0.0.0.0/0            127.0.0.11           udp dpt:53 to:127.0.0.11:49614  

Chain DOCKER_POSTROUTING (1 references)  
 pkts bytes target     prot opt in     out     source               destination  
    0     0 SNAT       tcp  --  *      *       127.0.0.11           0.0.0.0/0            tcp spt:45997 to::53  
    0     0 SNAT       udp  --  *      *       127.0.0.11           0.0.0.0/0            udp spt:49614 to::53
```
As you can see, the eDNS isn't actually listening on port 53. Due to the rerouting to higher dynamic ports, the initial DNS requests couldn't be filtered with _--dport 53_. Your requests will then be forwarded to the DNS you specified with the _--dns_ option or otherwise your hosts DNS. The requests from the eDNS itself can't be filtered by `--gid-owner vpn` anymore, because the eDNS runs as root.

**Firewalling embedded DNS requests:**
To filter eDNS requests i first had to block all output to _127.0.0.11_, because the eDNS ports are changing dynamically:
`iptables -A OUTPUT -o lo ! -d 127.0.0.11 -j ACCEPT`
If eDNS _127.0.0.11_ is used in _/etc/resolv.conf_ then allow all DNS requests to _127.0.0.11_ that are sent from the openvpn process with the gid of vpn.
Now we have to allow all udp port 53 DNS requests coming from the eDNS, because these couldn't be filtered by gid. This will not allow the initial DNS requests, because of the port rerouting.
```
if grep -Fq "127.0.0.11" /etc/resolv.conf; then
        iptables -A OUTPUT -d 127.0.0.11 -m owner --gid-owner vpn -j ACCEPT || 
            iptables -A OUTPUT -d 127.0.0.11 -j ACCEPT
        iptables -A OUTPUT -p udp -m udp --dport 53 -j ACCEPT; fi
```
I removed the global _ACCEPT_ on udp port 53 and only allow this if _--gid-owner_ filtering is not available:
```
iptables -A OUTPUT -p udp -m owner --gid-owner vpn -j ACCEPT || {
        iptables -A OUTPUT -p tcp -m tcp --dport $port -j ACCEPT
        iptables -A OUTPUT -p udp -m udp --dport $port -j ACCEPT
        iptables -A OUTPUT -p udp -m udp --dport 53 -j ACCEPT; }
```
Since all containers attached to the vpn's network also use the eDNS _127.0.0.11_, i had to allow requests form all applications once the vpn routes are up:
```
filter_embedded_dns() {
    ext_args+=("--route-up '/sbin/iptables -A OUTPUT -d 127.0.0.11 -j ACCEPT'")
    ext_args+=('--route-pre-down')
    ext_args+=("'/bin/sh -c \"iptables -D OUTPUT -d 127.0.0.11 -j ACCEPT\"'")
}
```
The down script command had to be called via `sh -c` because this discards [multiple arguments](https://github.com/OpenVPN/openvpn/blob/3b06b57d9f1d972ec16f0893d06697439c1bb1fe/src/openvpn/init.c#L177) that are added by openvpn, which caused an error as iptable options. All arguments were passed inside an argv array to [execve(cmd, argv, envp);](https://github.com/OpenVPN/openvpn/blob/01a3c876d4911ff7ea82b04edeb43defdebc69d7/src/openvpn/run_command.c#L153) so commenting them out by ;# was no option. I had to split the longer command over 2 lines because of your line width 80 restriction.

Once the vpn routes are up, all requests coming from the eDNS are successfully routed over the VPN. 

**Notes:**
- I suggest using custom networks (even default in docker-compose) and google/cloudflare DNS, set by --dns because the VPN dns option can't be used inside a read-only container because _/etc/resolv.conf_ can't be overwritten by the vpn dns up script.
- in a IPv6 custom network, docker still uses _127.0.0.11_ for container hostname resolving and IPv4 DNS requests, but the IPv6 DNS from _--dns_ or the host is inserted directly into _/etc/resolv.conf_, so all IPv6 DNS requests can be filtered by _--gid-owner vpn_

I had to change the _vpnportforward()_ loopback ip from _127.0.0.11_ to _127.0.0.111_ to avoid conflicts with the eDNS iptable rules.

I also added $ext_args for collecting extended arguments instead of declaring multiple variables like AUTH_COMMAND for every argument type. That way i was able to dynamically use auth and routing related stuff with mounted vpn configs without manually editing your preconfigured downloaded vpn configs, like adding _--redirect-gateway def1_. I went for the array approach, because string concatenation would have required a leading space before every openvpn argument.

Sorry for the long read!