### PR TITLE
Bringing back the DNS leak fix

### DIFF
--- a/openvpn.sh
+++ b/openvpn.sh
@@ -108,12 +108,12 @@ firewall() { local port="${1:-1194}" docker_network="$(ip -o addr show dev eth0|
     if grep -Fq "127.0.0.11" /etc/resolv.conf; then
         iptables -A OUTPUT -d 127.0.0.11 -m owner --gid-owner vpn -j ACCEPT \
         2>/dev/null && {
+            iptables -A OUTPUT -p udp -m udp --dport 53 -j ACCEPT
             ext_args+=" --route-up '/bin/sh -c \""
             ext_args+=" iptables -A OUTPUT -d 127.0.0.11 -j ACCEPT\"'"	
             ext_args+=" --route-pre-down '/bin/sh -c \""	
             ext_args+=" iptables -D OUTPUT -d 127.0.0.11 -j ACCEPT\"'"
-        } || iptables -A OUTPUT -d 127.0.0.11 -j ACCEPT
-        iptables -A OUTPUT -p udp -m udp --dport 53 -j ACCEPT; fi
+        } || iptables -A OUTPUT -d 127.0.0.11 -j ACCEPT; fi
     iptables -t nat -A POSTROUTING -o tap+ -j MASQUERADE
     iptables -t nat -A POSTROUTING -o tun+ -j MASQUERADE
     [[ -r $firewall_cust ]] && . $firewall_cust

--- a/openvpn.sh
+++ b/openvpn.sh
@@ -50,6 +50,10 @@ firewall() { local port="${1:-1194}" docker_network="$(ip -o addr show dev eth0|
         port="$(awk '/^remote / && NF ~ /^[0-9]*$/ {print $NF}' $conf |
                     grep ^ || echo 1194)"
 
+    test -f /proc/net/if_inet6 && { lsmod |grep -qF ip6table_filter || { \
+        echo "WARNING: ip6tables disabled!"
+        echo "Run 'sudo modprobe ip6table_filter' on your host"; };}
+
     ip6tables -F 2>/dev/null
     ip6tables -X 2>/dev/null
     ip6tables -P INPUT DROP 2>/dev/null

--- a/openvpn.sh
+++ b/openvpn.sh
@@ -104,10 +104,10 @@ firewall() { local port="${1:-1194}" docker_network="$(ip -o addr show dev eth0|
     if grep -Fq "127.0.0.11" /etc/resolv.conf; then
         iptables -A OUTPUT -d 127.0.0.11 -m owner --gid-owner vpn -j ACCEPT \
         2>/dev/null && {
-            ext_args+=" --route-up '/sbin/iptables"
-            ext_args+=" -A OUTPUT -d 127.0.0.11 -j ACCEPT'"	
-            ext_args+=" --route-pre-down '/bin/sh -c \"iptables"	
-            ext_args+=" -D OUTPUT -d 127.0.0.11 -j ACCEPT\"'"
+            ext_args+=" --route-up '/bin/sh -c \""
+            ext_args+=" iptables -A OUTPUT -d 127.0.0.11 -j ACCEPT\"'"	
+            ext_args+=" --route-pre-down '/bin/sh -c \""	
+            ext_args+=" iptables -D OUTPUT -d 127.0.0.11 -j ACCEPT\"'"
         } || iptables -A OUTPUT -d 127.0.0.11 -j ACCEPT
         iptables -A OUTPUT -p udp -m udp --dport 53 -j ACCEPT; fi
     iptables -t nat -A POSTROUTING -o tap+ -j MASQUERADE


### PR DESCRIPTION
I saw you reverted this fix because you thought it broke vpnportforward in [#284](https://github.com/dperson/openvpn-client/issues/284)
But it actually didn't.  
I know you added $firewall_cust, but this fix should be default and not custom!

You forgot to revert ${ext_args[*]} to $ext_args since its not an array anymore.

Stay safe!