### PR TITLE
Hotfix vpnportforward execution order

### DIFF
--- a/openvpn.sh
+++ b/openvpn.sh
@@ -301,7 +301,7 @@ while getopts ":hc:Ddf:a:m:o:p:R:r:v:" opt; do
         f) FIREWALL="true" ;;
         m) MSS="$OPTARG" ;;
         o) OTHER_ARGS+=" $OPTARG" ;;
-        p) eval vpnportforward $(sed 's/^/"/; s/$/"/; s/;/" "/g' <<< $OPTARG) ;;
+        p) export VPNPORT_OPT$OPTIND="$OPTARG" ;;
         R) return_route6 "$OPTARG" ;;
         r) return_route "$OPTARG" ;;
         v) VPN="$OPTARG" ;;


### PR DESCRIPTION
When setting vpnportforward over command, the forward rules are added before the firewall rules.
The firewall function will flush the forward rules with `iptables -F` but keeps the nat rule:
```
iptables -t nat -A OUTPUT -p $protocol --dport $port -j DNAT \
                --to-destination 127.0.0.111:$port
```
The naked nat rule will then block all outgoing traffic to forwarded ports by forwarding them to the localhost.

Fixed by pushing the command port arguments to the environment and processing them later after firewall rules are up

