### PR TITLE
Clean up noisy healthcheck log

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk --no-cache --no-progress upgrade && \
 COPY openvpn.sh /usr/bin/
 
 HEALTHCHECK --interval=60s --timeout=15s --start-period=120s \
-             CMD curl -L 'https://api.ipify.org'
+             CMD curl -sSL 'https://api.ipify.org'
 
 VOLUME ["/vpn"]
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -12,7 +12,7 @@ RUN apk --no-cache --no-progress upgrade && \
 COPY openvpn.sh /usr/bin/
 
 HEALTHCHECK --interval=60s --timeout=15s --start-period=120s \
-             CMD curl -L 'https://api.ipify.org'
+             CMD curl -sSL 'https://api.ipify.org'
 
 VOLUME ["/vpn"]
 

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -12,7 +12,7 @@ RUN apk --no-cache --no-progress upgrade && \
 COPY openvpn.sh /usr/bin/
 
 HEALTHCHECK --interval=60s --timeout=15s --start-period=120s \
-             CMD curl -L 'https://api.ipify.org'
+             CMD curl -sSL 'https://api.ipify.org'
 
 VOLUME ["/vpn"]
 


### PR DESCRIPTION
Turn health check logs from this
```
$ docker inspect --format "{{json .State.Health }}" test | jq .Log[].Output
"  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0\r  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0\r  0     0    0     0    0     0      0      0 --:--:--  0:00:03 --:--:--     0\r100    13  100    13    0     0      3      0  0:00:04  0:00:03  0:00:01     3\n<REDACTED>"
```
to this
```
$ docker inspect --format "{{json .State.Health }}" test | jq .Log[].Output
"<REDACTED>"
```
Thanks for the great image!