### PR TITLE
global_return_routes fix

### DIFF
--- a/openvpn.sh
+++ b/openvpn.sh
@@ -137,20 +137,24 @@ global_return_routes() { local if=$(ip r | awk '/^default/ {print $5; quit}')
     ip=$(ip -4 a show dev $if | awk -F '[ \t/]+' '/inet .*global/ {print $3}')
 
     for i in $ip6; do
-        ip -6 rule | grep -q "$i\\>" || ip -6 rule add from $i lookup 10
+        ip -6 rule show table 10 | grep -q "$i\\>" || 
+            ip -6 rule add from $i lookup 10
         ip6tables -S 2>/dev/null | grep -q "$i\\>" ||
-                    ip6tables -A INPUT -d $i -j ACCEPT 2>/dev/null
+            ip6tables -A INPUT -d $i -j ACCEPT 2>/dev/null
     done
     for g in $gw6; do
-        ip -6 route | grep -q "$i\\>" || ip -6 route add default via $g table 10
+        ip -6 route show table 10 | grep -q "$i\\>" || 
+            ip -6 route add default via $g table 10
     done
 
     for i in $ip; do
-        ip -4 rule | grep -q "$i\\>" || ip rule add from $i lookup 10
+        ip -4 rule show table 10 | grep -q "$i\\>" || 
+            ip rule add from $i lookup 10
         iptables -S | grep -q "$i\\>" || iptables -A INPUT -d $i -j ACCEPT
     done
     for g in $gw; do
-        ip -4 route | grep -q "$i\\>" || ip route add default via $g table 10
+        ip -4 route show table 10 | grep -q "$i\\>" || 
+            ip route add default via $g table 10
     done
 }
 

--- a/openvpn.sh
+++ b/openvpn.sh
@@ -143,7 +143,7 @@ global_return_routes() { local if=$(ip r | awk '/^default/ {print $5; quit}')
             ip6tables -A INPUT -d $i -j ACCEPT 2>/dev/null
     done
     for g in $gw6; do
-        ip -6 route show table 10 | grep -q "$i\\>" || 
+        ip -6 route show table 10 | grep -q "$g\\>" || 
             ip -6 route add default via $g table 10
     done
 
@@ -153,7 +153,7 @@ global_return_routes() { local if=$(ip r | awk '/^default/ {print $5; quit}')
         iptables -S | grep -q "$i\\>" || iptables -A INPUT -d $i -j ACCEPT
     done
     for g in $gw; do
-        ip -4 route show table 10 | grep -q "$i\\>" || 
+        ip -4 route show table 10 | grep -q "$g\\>" || 
             ip route add default via $g table 10
     done
 }


### PR DESCRIPTION
Hey @dperson, long time no see!
i started using your docker hub image and found out that my global return routes aren't working anymore.

```
ip -4 route | grep -q "$i\\>" || 
    ip route add default via $g table 10
```

the route on table 10 wasn't added because it falsely detected the default gateway route as a duplicate.
To check if the table 10 entries already exists you have to add `show table 10` on the ip commands like in my fix here.

You also had a copy paste error. You referenced `$i` instead of `$g` in the `for g in $gw` loops.

This will fix https://github.com/dperson/openvpn-client/issues/316 and all other remote port issues

Let me know when the fix is on docker hub

Cheers!