### PR TITLE
Explain how to fix update-resolv-conf errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,12 @@ but adding your vpn user and password by command line
     sudo docker run -it --cap-add=NET_ADMIN --device /dev/net/tun --name vpn \
             -v /some/path:/vpn -d dperson/openvpn-client -a 'username;password'
 
+**Note:** If you are using a downloaded configuration file from a VPN provider, you may see errors relating to "/etc/openvpn/update-resolv-conf".
+This script does not exist in Alpine linux, so you should change the `up` and `down` lines in your providers' config file to this instead:
+
+    up /etc/openvpn/up.sh
+    down /etc/openvpn/down.sh
+
 # User Feedback
 
 ## Issues


### PR DESCRIPTION
Documents [a solution](https://github.com/dperson/openvpn-client/issues/90#issuecomment-462167761) for the following error when using pre-made config files downloaded from VPN providers:

```
--up script fails with '/etc/openvpn/update-resolv-conf': No such file or directory
```

I have seen two major VPN providers include a baked in reference to this script in their downloadable configs and they assume that it's kicking in to update your DNS after the connection is established, so it's helpful for users with those configs to know how to fix the problem.

Thanks to @mil1i for the fix.

Related issues:
dperson/openvpn-client#90
dperson/openvpn-client#344
dperson/openvpn-client#271